### PR TITLE
Remove duplicate system message in interpreter

### DIFF
--- a/adventure.py
+++ b/adventure.py
@@ -75,11 +75,11 @@ llm_with_tools = core.llm.bind_tools([move_room])
 
 def interpret_action(state: GameState):
     """Use the LLM to respond to the player and call tools if needed."""
-    messages = [
-        {"role": "system", "content": "You control the world. Respond concisely."},
-        *state["messages"],
-    ]
-    resp = llm_with_tools.invoke(messages)
+    # The conversation history already captures the prior context, so we
+    # simply pass the stored messages directly to the model. Adding a
+    # system prompt on every invocation causes the model to echo the user
+    # input, so it has been removed.
+    resp = llm_with_tools.invoke(state["messages"])
     return {"messages": [resp]}
 
 


### PR DESCRIPTION
## Summary
- prevent user input echo by removing system prompt from interpret_action

## Testing
- `python -m py_compile adventure.py main.py core.py`
- `python main.py` *(fails: ServiceUnavailable due to SSL error)*

------
https://chatgpt.com/codex/tasks/task_e_684140e7f9d483309411edc84fa9841f