### PR TITLE
Fix repeated user messages

### DIFF
--- a/adventure.py
+++ b/adventure.py
@@ -118,9 +118,10 @@ def play(start_room: str = "hall"):
         for event in graph.stream(command, config, stream_mode="values"):
             state = event  # capture latest state
             if "messages" in event:
-                for msg in event["messages"][prev_len:]:
+                new_msgs = event["messages"][prev_len:]
+                for msg in new_msgs:
                     print(msg.content)
-                prev_len = len(event["messages"])
+                prev_len += len(new_msgs)
             if "__interrupt__" in event:
                 prompt = event["__interrupt__"][0].value
                 user_input = input(prompt)


### PR DESCRIPTION
## Summary
- ensure prev_len only increases so user messages don't get reprinted

## Testing
- `python -m py_compile adventure.py`
- `python -m unittest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6842106f083c83309fecca87851038fb