### PR TITLE
Refactor graph for multiple tool calls

### DIFF
--- a/adventure.py
+++ b/adventure.py
@@ -126,7 +126,11 @@ graph_builder.add_conditional_edges(
     "interpret", tools_condition, {"tools": "tools", "__end__": "check_summary"}
 )
 
-graph_builder.add_edge("tools", "interpret")
+graph_builder.add_conditional_edges(
+    "tools",
+    lambda state: "check_summary" if state.get("need_summary") else "interpret",
+    {"check_summary": "check_summary", "interpret": "interpret"},
+)
 
 graph_builder.add_conditional_edges(
     "check_summary",


### PR DESCRIPTION
## Summary
- extend game state with `need_summary` flag
- return to `interpret` after executing tools and decide whether to summarize
- reset `need_summary` after summarization
- initialize `need_summary` in the play loop

## Testing
- `python main.py <<'EOF'
 go east
 go west
 exit
 EOF`

------
https://chatgpt.com/codex/tasks/task_e_684266fe55a0833087c202c388f4c1e0