### PR TITLE
Limit conversation history after moving rooms

### DIFF
--- a/adventure.py
+++ b/adventure.py
@@ -7,7 +7,8 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.types import Command, interrupt
 from langchain.tools import tool
 from langchain_core.tools import InjectedToolCallId
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import ToolMessage, RemoveMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 
 import core
 
@@ -99,8 +100,14 @@ def move_room(
         tool_call_id=tool_call_id,
         name="move_room",
     )
+    # Clear previous messages so the model doesn't see old context
+    clear = RemoveMessage(id=REMOVE_ALL_MESSAGES)
     return Command(
-        update={"current_room": new_room, "messages": [msg], "need_summary": True}
+        update={
+            "current_room": new_room,
+            "messages": [clear, msg],
+            "need_summary": True,
+        }
     )
 
 

--- a/adventure.py
+++ b/adventure.py
@@ -182,9 +182,10 @@ def play(start_room: str = "hall"):
         for event in graph.stream(command, config, stream_mode="values"):
             state = event  # capture latest state
             if "messages" in event:
-                # If the conversation was cleared, reset our counter
+                # If the conversation history shrinks, skip any previously
+                # printed messages so we don't reprint stale narration.
                 if len(event["messages"]) < prev_len:
-                    prev_len = 0
+                    prev_len = len(event["messages"])
                 if len(event["messages"]) > prev_len:
                     for msg in event["messages"][prev_len:]:
                         # Skip tool messages so the LLM can narrate the result


### PR DESCRIPTION
## Summary
- clear the message history when changing rooms so the LLM can't see earlier turns

## Testing
- `python main.py <<'EOF'
go east
go west
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68427a7c4b80833086671bbe1b78da25